### PR TITLE
EGG-37: Simplify Events

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,14 +1,9 @@
 import React from 'react'
-import { AnalyticsClient } from '@/events/AnalyticsClient'
 import { EventName } from '@/events/types'
-import { getSessionInfo } from '@/events/session'
+import { sendEvent } from '@/events/events'
 
 export default async function About() {
-  const analyticsClient = new AnalyticsClient()
-
-  const { ip, sessionID } = await getSessionInfo()
-  analyticsClient.track({ name: EventName.PageViewEvent, properties: { distinct_id: sessionID, path: '/about', ip } })
-
+  await sendEvent(EventName.PageViewEvent, { path: '/about' })
 
   return (
     <main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
-import { AnalyticsClient } from '@/events/AnalyticsClient'
 import { EventName } from '@/events/types'
-import { getSessionInfo } from '@/events/session'
 import { HeroSection } from '@/components/HeroSection/HeroSection'
 import { FAQSection } from '@/components/FAQ/FAQ'
 import { WhatToExpect } from '@/components/WhatToExpect/WhatToExpect'
@@ -9,15 +7,14 @@ import { HowICanHelp } from '@/components/HowICanHelp/HowICanHelp'
 import { PatientTestimonials } from '@/components/PatientTestimonials/PatientTestimonials'
 import { WhyGonsteadWorks } from '@/components/WhyGonsteadWorks/WhyGonsteadWorks'
 import { AboutMatt } from '@/components/AboutMatt/AboutMatt'
+import { sendEvent } from '@/events/events'
 
 export const metadata = {
   title: 'Bentley Chiropractic | Home',
 }
 
 export default async function Home() {
-  const analyticsClient = new AnalyticsClient()
-  const { ip, sessionID } = await getSessionInfo()
-  analyticsClient.track({ name: EventName.PageViewEvent, properties: { distinct_id: sessionID, path: '/', ip } })
+  await sendEvent(EventName.PageViewEvent, { path: '/' })
 
   const sections = [
     <HowICanHelp key={'help'} />,

--- a/src/app/services/[serviceName]/page.tsx
+++ b/src/app/services/[serviceName]/page.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
-import { AnalyticsClient } from '@/events/AnalyticsClient'
 import { EventName } from '@/events/types'
-import { getSessionInfo } from '@/events/session'
+import { sendEvent } from '@/events/events'
 
 interface PageParams {
   serviceName: string
@@ -9,16 +8,7 @@ interface PageParams {
 
 export default async function ServicePage({ params }: { params: PageParams }) {
   const { serviceName } = params
-  const analyticsClient = new AnalyticsClient()
-
-  const { ip, sessionID } = await getSessionInfo()
-  analyticsClient.track({
-    name: EventName.PageViewEvent, properties: {
-      distinct_id: sessionID,
-      path: `/services/${serviceName}`,
-      ip
-    }
-  })
+  await sendEvent(EventName.PageViewEvent, { path: `/services/${serviceName}` })
 
   return (
     <main>

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,13 +1,9 @@
 import React from 'react'
-import { AnalyticsClient } from '@/events/AnalyticsClient'
 import { EventName } from '@/events/types'
-import { getSessionInfo } from '@/events/session'
+import { sendEvent } from '@/events/events'
 
 export default async function Services() {
-  const analyticsClient = new AnalyticsClient()
-
-  const { ip, sessionID } = await getSessionInfo()
-  analyticsClient.track({ name: EventName.PageViewEvent, properties: { distinct_id: sessionID, path: '/services', ip } })
+  await sendEvent(EventName.PageViewEvent, { path: '/services' })
 
   return (
     <main>

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -1,13 +1,9 @@
 import React from 'react'
-import { AnalyticsClient } from '@/events/AnalyticsClient'
 import { EventName } from '@/events/types'
-import { getSessionInfo } from '@/events/session'
+import { sendEvent } from '@/events/events'
 
 export default async function Testimonials() {
-  const analyticsClient = new AnalyticsClient()
-
-  const { ip, sessionID } = await getSessionInfo()
-  analyticsClient.track({ name: EventName.PageViewEvent, properties: { distinct_id: sessionID, path: '/testimonials', ip } })
+  await sendEvent(EventName.PageViewEvent, { path: '/testimonials' })
 
   return (
     <main>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,39 +1,32 @@
 'use client'
-import React, { useContext } from 'react'
+import React from 'react'
 import { Button, ButtonVariant } from '@/components/Button/Button'
-import { sendEventFromClient } from '@/events/events'
-import { AnalyticsContext } from '@/events/AnalyticsProvider'
+import { sendEvent } from '@/events/events'
 import { EventName } from '@/events/types'
 import { Facebook, Instagram } from 'react-feather'
-import { ExternalURL } from '@/urls'
+import { ExternalURL, URLMap } from '@/urls'
 
 
 export const Footer: React.FC = () => {
-  const { getEventProperties } = useContext(AnalyticsContext)
-
   const scheduleAppointment = () => {
-    const eventProps = getEventProperties()
-    void sendEventFromClient({
-      name: EventName.ClickEvent,
-      properties: {
-        ...eventProps,
+    void sendEvent(
+      EventName.ClickEvent,
+      {
         element: 'schedule-appointment-footer',
       }
-    })
-    window.open(ExternalURL.Booking, '_blank')
+    )
+    window.open(URLMap[ExternalURL.Booking], '_blank')
   }
 
   const openSocial = (platform: ExternalURL) => {
-    const eventProps = getEventProperties()
-    void sendEventFromClient({
-      name: EventName.ClickEvent,
-      properties: {
-        ...eventProps,
+    void sendEvent(
+      EventName.ClickEvent,
+      {
         element: `open-social-${platform}`,
       }
-    })
+    )
 
-    window.open(platform, '_blank')
+    window.open(URLMap[platform], '_blank')
   }
 
   return (

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Menu } from 'react-feather'
 import { LinkButton } from '@/components/Button/LinkButton'
 import { EventName } from '@/events/types'
-import { ExternalURL } from '@/urls'
+import { ExternalURL, URLMap } from '@/urls'
 import Image from 'next/image'
 
 
@@ -58,7 +58,7 @@ export const Nav: React.FC<NavProps> = () => {
             <li>
               <LinkButton
                 stretch
-                href={ExternalURL.Booking}
+                href={URLMap[ExternalURL.Booking]}
                 eventName={EventName.BookAppointment}
                 eventProperties={{ item: 'nav-bar' }}
               >
@@ -79,7 +79,7 @@ export const Nav: React.FC<NavProps> = () => {
             <li className={'pl-4 pr-8 mt-12'}>
               <LinkButton
                 stretch
-                href={ExternalURL.Booking}
+                href={URLMap[ExternalURL.Booking]}
                 eventName={EventName.BookAppointment}
                 eventProperties={{ item: 'nav-bar' }}
               >

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -1,6 +1,6 @@
 'use server'
 import { AnalyticsClient } from '@/events/AnalyticsClient'
-import { AnalyticsEvent, EventName } from '@/events/types'
+import { EventName } from '@/events/types'
 import { getSessionInfo } from '@/events/session'
 
 const ENVIRONMENT = process.env.NODE_ENV
@@ -8,10 +8,6 @@ const ENVIRONMENT = process.env.NODE_ENV
 // This is a server action which can be called by Client components.
 // It sends an event to the analytics provider from the server, therefby
 // bypassing any client-side blockers.
-export const sendEventFromClient = async (event: AnalyticsEvent) => {
-  const client = new AnalyticsClient()
-  client.track(event)
-}
 
 export const sendEvent = async (name: EventName, properties: Record<string, string >) => {
   const client = new AnalyticsClient()

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,6 +1,12 @@
 /* eslint no-unused-vars: 0 */
 export enum ExternalURL {
-  Booking = 'https://bentleychiropractic.janeapp.com/#/staff_member/1/treatment/1',
-  Facebook = 'https://www.facebook.com/bentleychiropracticstl',
-  Instagram = 'https://www.instagram.com/bentleychiropracticstl/',
+  Booking = 'booking',
+  Facebook = 'facebook',
+  Instagram = 'instagram',
+}
+
+export const URLMap = {
+  [ExternalURL.Booking]: 'https://bentleychiropractic.janeapp.com/#/staff_member/1/treatment/1',
+  [ExternalURL.Facebook]: 'https://www.facebook.com/bentleychiropracticstl',
+  [ExternalURL.Instagram]: 'https://www.instagram.com/bentleychiropracticstl/',
 }


### PR DESCRIPTION
## Summary of changes

- Make everything use the `sendEvent` function since it's much cleaner
     - This also makes it much easier to send shared event data, like the node environment, so we can filter it out more easily in reporting.
- Add a URLMap that's separate from ExternalURL so that it's easier to access the name of the social media for event tracking